### PR TITLE
fix: prevent creating color names with whitespace

### DIFF
--- a/src/FastTextColorSettings.ts
+++ b/src/FastTextColorSettings.ts
@@ -1,10 +1,11 @@
 import FastTextColorPlugin from 'main';
-import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import { App, ButtonComponent, Notice, PluginSettingTab, Setting } from "obsidian";
 import { TextColor } from "./color/TextColor";
 import { TextColorTheme } from "./color/TextColorTheme";
 import { confirmByModal } from "./utils/ConfirmationModal"
 import { CreateNewThemeModal } from './utils/CreateNewThemeModal';
 import { getKeyBindWithModal } from "./utils/KeyBindModal"
+import { validateColorName } from './utils/validateColorName';
 
 // --------------------------------------------------------------------------
 //                            CONSTANTS
@@ -283,13 +284,19 @@ export class FastTextColorPluginSettingTab extends PluginSettingTab {
 			count++;
 		});
 
-		new Setting(containerEl)
+		const addNewColorGroup = new Setting(containerEl)
 			.setName("Add new color to theme")
 			.setClass("ftc-settings-theme-footer")
 			.addText(txt => {
 				txt
 					.setValue(this.newId == '' ? (getColors(settings).length + 1).toString() : this.newId)
 					.onChange(value => {
+						const isValid = validateColorName(value);
+						const button = addNewColorGroup
+							.components.filter((component): component is ButtonComponent => 'buttonEl' in component)
+							.at(0);
+						button?.setDisabled(!isValid);
+						button?.setTooltip(isValid ? '' : 'The color name must not contain any whitespace characters.')
 						this.newId = value;
 					})
 			})
@@ -306,7 +313,7 @@ export class FastTextColorPluginSettingTab extends PluginSettingTab {
 						colors.push(new TextColor("#ffffff", newColorName, getCurrentTheme(settings, this.editThemeIndex).name));
 						await this.plugin.saveSettings();
 						this.display();
-					})
+					});
 			})
 		// .addButton(btn => {
 		// 	btn

--- a/src/utils/validateColorName.ts
+++ b/src/utils/validateColorName.ts
@@ -1,0 +1,3 @@
+export function validateColorName(name: string): boolean {
+	return name.length > 0 && !/\s/.test(name);
+}

--- a/test/utils/validateColorName.test.ts
+++ b/test/utils/validateColorName.test.ts
@@ -1,0 +1,11 @@
+import { validateColorName } from "../../src/utils/validateColorName";
+
+it('returns `true` when the color name contain valid characters; otherwise, it returns `false`', () => {
+	expect(validateColorName('')).toBe(false);
+	expect(validateColorName(' ')).toBe(false);
+	expect(validateColorName('a')).toBe(true);
+	expect(validateColorName('9')).toBe(true);
+	expect(validateColorName('b1')).toBe(true);
+	expect(validateColorName('b1_dD_8')).toBe(true);
+	expect(validateColorName('b1/dD/8')).toBe(true);
+});


### PR DESCRIPTION
Validate a color name: if the name contains whitespace, the submit button becomes disabled and has a tooltip describing why it's disabled.

Issue #43